### PR TITLE
Imported Base.rand to fix rand(Haar)

### DIFF
--- a/src/HaarMeasure.jl
+++ b/src/HaarMeasure.jl
@@ -1,5 +1,5 @@
-export rand, NeedPiecewiseCorrection
-import Base.rand
+export NeedPiecewiseCorrection
+
 
 # Computes samplex of real or complex Haar matrices of size nxn
 #

--- a/src/RandomMatrices.jl
+++ b/src/RandomMatrices.jl
@@ -6,6 +6,8 @@ module RandomMatrices
 importall Distributions
 using Catalan
 
+import Base.rand
+
 #If the GNU Scientific Library is present, turn on additional functionality.
 _HAVE_GSL = try
   using GSL

--- a/test/FormalPowerSeries.jl
+++ b/test/FormalPowerSeries.jl
@@ -4,7 +4,7 @@
 #
 # Jiahao Chen <jiahao@mit.edu> 2013
 
-using Test
+using Base.Test
 using RandomMatrices
 
 MaxSeriesSize=10


### PR DESCRIPTION
rand(Haar) was broken due to confusion between rand.  importing Base.rand rectified the issue.  I also changed "using Test" to "using Base.Test" in one of the unit tests.  Unfortunately, the unit tests do not pass, due to "has" and "unsafe_assign" not being defined.  I don't believe these are issues I've introduced.
