### PR TITLE
Fixed check of on whether to include InvariantEnsembles to work on Windows

### DIFF
--- a/src/RandomMatrices.jl
+++ b/src/RandomMatrices.jl
@@ -50,7 +50,7 @@ include("StatisticalTests.jl")
 include("StochasticProcess.jl")
 
 #Invariant ensembles
-if filesize(Pkg.dir("ApproxFun")) != 0
+if filemode(Pkg.dir("ApproxFun")) != 0
     include("InvariantEnsembles.jl")
 end
 


### PR DESCRIPTION
The InvariantEnsembles package was not loading in Windows since filesize of a directory was zero.  Changing to filemode should fix the issue.
