### PR TITLE
Fixes for Julia v1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ addons:
 os:
     - linux
 julia:
-    - 0.6
+    - 0.7
+    - 1.0
     - nightly
 matrix:
   allow_failures:
@@ -18,4 +19,4 @@ notifications:
 #    - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 #    - julia -e 'Pkg.clone(pwd()); Pkg.build("RandomMatrices"); Pkg.test("RandomMatrices"; coverage=true)'
 after_success:
-    - julia -e 'Pkg.add("Coverage"); cd(Pkg.dir("RandomMatrices")); using Coverage; Coveralls.submit(process_folder()); Codecov.submit(process_folder())'
+    - julia -e 'using Pkg; Pkg.add("Coverage"); cd(Pkg.dir("RandomMatrices")); using Coverage; Coveralls.submit(process_folder()); Codecov.submit(process_folder())'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,7 @@
-julia 0.6
-Combinatorics 0.2
-Distributions 0.8.10
-GSL 0.3.1
-Compat 0.60
-SpecialFunctions 0.4.0
-FastGaussQuadrature 0.3.0
+julia 0.7
+Combinatorics 0.7
+Distributions 0.16
+GSL 0.4
+SpecialFunctions 0.7
+FastGaussQuadrature 0.3
+Requires 0.5

--- a/src/FastHistogram.jl
+++ b/src/FastHistogram.jl
@@ -10,7 +10,7 @@ export hist_eig
 # of the determinant is stored.
 #
 #For general matrices, this is slower than hist(eigvals(M), bins) and is NOT recommended
-function hist_eig{GridPoint <: Number}(M::AbstractMatrix, bins::Vector{GridPoint})
+function hist_eig(M::AbstractMatrix, bins::Vector{GridPoint}) where {GridPoint <: Number}
   n = size(M)[1]
   NumBins = length(bins)
   histogram = zeros(NumBins)
@@ -38,7 +38,7 @@ end
 #   Cy P. Chan, "Sturm Sequences and the Eigenvalue Distribution of
 #   the Beta-Hermite Random Matrix Ensemble", M.Sc. thesis (MIT), 2007
 #
-function hist_eig{GridPoint <: Number}(M::SymTridiagonal, bins::Vector{GridPoint})
+function hist_eig(M::SymTridiagonal, bins::Vector{GridPoint}) where {GridPoint <: Number}
   n = size(M)[1]
   NumBins = length(bins)
   histogram = zeros(NumBins)

--- a/src/GaussianEnsembles.jl
+++ b/src/GaussianEnsembles.jl
@@ -47,7 +47,7 @@ Synonym for GaussianHermite{β}
 """
 const Wigner{β} = GaussianHermite{β}
 
-rand{β}(d::Type{Wigner{β}}, dims...) = rand(d(), dims...)
+rand(d::Type{Wigner{β}}, dims...) where {β} = rand(d(), dims...)
 
 function rand(d::Wigner{1}, n::Int)
     A = randn(n, n)
@@ -70,10 +70,10 @@ function rand(d::Wigner{4}, n::Int)
     return Hermitian((A + A') / normalization)
 end
 
-rand{β}(d::Wigner{β}, n::Int) =
+rand(d::Wigner{β}, n::Int) where {β} =
     throw(ValueError("Cannot sample random matrix of size $n x $n for β=$β"))
 
-function rand{β}(d::Wigner{β}, dims...)
+function rand(d::Wigner{β}, dims...) where {β}
     if length(dims)==2 && dims[1] == dims[2]
 	return rand(d, dims[1])
     else
@@ -89,7 +89,7 @@ Unlike for `rand(Wigner{β}, n)`, which is restricted to β=1,2 or 4,
 
 The β=∞ case is defined in Edelman, Persson and Sutton, 2012
 """
-function tridrand{β}(d::Wigner{β}, n::Int)
+function tridrand(d::Wigner{β}, n::Int) where {β}
     χ(df::Real) = rand(Distributions.Chi(df))
     if β≤0
         throw(ValueError("β = $β cannot be nonpositive"))
@@ -103,7 +103,7 @@ function tridrand{β}(d::Wigner{β}, n::Int)
     end
 end
 
-function tridrand{β}(d::Wigner{β}, dims...)
+function tridrand(d::Wigner{β}, dims...) where {β}
     if length(dims)==2 && dims[1] == dims[2]
 	return rand(d, dims[1])
     else
@@ -119,7 +119,7 @@ eigvalrand(d::Wigner, n::Int) = eigvals(tridrand(d, n))
 """
 Calculate Vandermonde determinant term
 """
-function VandermondeDeterminant{Eigenvalue<:Number}(λ::AbstractVector{Eigenvalue}, β::Real)
+function VandermondeDeterminant(λ::AbstractVector{Eigenvalue}, β::Real) where {Eigenvalue<:Number}
     n = length(λ)
     Vandermonde = one(Eigenvalue)^β
     for j=1:n, i=1:j-1
@@ -131,7 +131,7 @@ end
 """
 Calculate joint eigenvalue density
 """
-function eigvaljpdf{β,Eigenvalue<:Number}(d::Wigner{β}, λ::AbstractVector{Eigenvalue})
+function eigvaljpdf(d::Wigner{β}, λ::AbstractVector{Eigenvalue}) where {β,Eigenvalue<:Number}
     n = length(λ)
     #Calculate normalization constant
     c = (2π)^(-n/2)
@@ -167,7 +167,7 @@ function rand(d::GaussianLaguerre, dims::Dim2)
     X = randn(dims) + im*randn(dims)
     Y = randn(dims) + im*randn(dims)
     A = [X Y; -conj(Y) conj(X)]
-    error(@sprintf("beta = %d is not implemented", d.beta))
+    error("beta = $(d.beta) is not implemented")
   end
   return (A * A') / dims[1]
 end
@@ -175,7 +175,7 @@ end
 #Generates a NxN bidiagonal Wishart matrix
 function bidrand(d::GaussianLaguerre, m::Integer)
   if d.a <= d.beta*(m-1)/2.0
-    error(@sprintf("Given your choice of m and beta, a must be at least %f (You said a = %f)", d.beta*(m-1)/2.0, d.a))
+      error("Given your choice of m and beta, a must be at least $(d.beta*(m-1)/2.0) (You said a = $(d.a))")
   end
   Bidiagonal([chi(2*d.a-i*d.beta) for i=0:m-1], [chi(d.beta*i) for i=m-1:-1:1], true)
 end
@@ -191,7 +191,7 @@ end
 eigvalrand(d::GaussianLaguerre, m::Integer) = eigvals(tridrand(d, m))
 
 #TODO Check m and ns
-function eigvaljpdf{Eigenvalue<:Number}(d::GaussianLaguerre, lambda::Vector{Eigenvalue})
+function eigvaljpdf(d::GaussianLaguerre, lambda::Vector{Eigenvalue}) where {Eigenvalue<:Number}
   m = length(lambda)
   #Laguerre parameters
   p = 0.5*d.beta*(m-1) + 1.0
@@ -317,7 +317,7 @@ function eigvalrand(d::GaussianJacobi, n::Integer)
 end
 
 #TODO Check m and ns
-function eigvaljpdf{Eigenvalue<:Number}(d::GaussianJacobi, lambda::Vector{Eigenvalue})
+function eigvaljpdf(d::GaussianJacobi, lambda::Vector{Eigenvalue}) where {Eigenvalue<:Number}
   m = length(lambda)
   #Jacobi parameters
   a1, a2 = d.a, d.b

--- a/src/Ginibre.jl
+++ b/src/Ginibre.jl
@@ -27,7 +27,7 @@ function rand(W::Ginibre)
     end
 end
 
-function jpdf{z<:Complex}(Z::AbstractMatrix{z})
+function jpdf(Z::AbstractMatrix{z}) where {z<:Complex}
     pi^(size(Z,1)^2)*exp(-trace(Z'*Z))
 end
 

--- a/src/Haar.jl
+++ b/src/Haar.jl
@@ -1,5 +1,5 @@
 export permutations_in_Sn, compose, cycle_structure, data, part, #Functions working with partitions and permutations
-    partition, Haar, expectation, WeingartenUnitary
+    partition, Haar, expectation, WeingartenUnitary, Stewart
 
 
 const partition = Vector{Int}
@@ -26,7 +26,7 @@ function permutations_in_Sn(n::Integer)
     P = permutation_calloc(n)
     while true
         produce(P)
-        try permutation_next(P) catch break end
+        try permutation_next(P) catch; break end
     end
 end
 
@@ -101,12 +101,12 @@ function expectation(X::Expr)
     Qidx=[] #Indices for Haar matrices
     Qpidx=[] #Indices for ctranspose of Haar matrices
     Others=[]
-    MyQ=None
+    MyQ=Nothing
     for i=1:n
         thingy=X.args[i+1]
         if isa(thingy, Symbol)
             if isa(eval(thingy), Haar)
-                if MyQ==None MyQ=thingy end
+                if MyQ==Nothing MyQ=thingy end
                 if MyQ == thingy
                     Qidx=[Qidx; i]
                 else

--- a/src/InvariantEnsembles.jl
+++ b/src/InvariantEnsembles.jl
@@ -21,7 +21,7 @@
 
 
 module InvariantEnsembles
-    using ApproxFun, RandomMatrices, Compat
+    using RandomMatrices, RandomMatrices.ApproxFun
 
 export InvariantEnsemble
 
@@ -47,7 +47,7 @@ function orthonormalpolynomials(μ0,α::Function,β::Function,d,n)
 end
 
 function legendrepolynomials(n)
-  orthonormalpolynomials(1./sqrt(2),k->0,k->sqrt(k^2./(4k^2-1)),[-1.,1.],n)
+  orthonormalpolynomials(1 ./ sqrt(2), k->0, k->sqrt(k^2 ./ (4k^2-1)), [-1.,1.], n)
 end
 function scaledhermitepolynomials(n)
   orthonormalpolynomials(n^(1/4)/(1.0π)^(1/4),k->0,k->sqrt((k)/(2n)),[-3.,3.],n)
@@ -95,7 +95,7 @@ Base.size(ie::InvariantEnsemble,n)=size(ie.basis,2)
 
 #Takes in list of OPs, constructs phis
 # can be unstable for large n
-function InvariantEnsemble{F<:Fun}(p::Array{F},V::Function,d,n::Integer)
+function InvariantEnsemble(p::Array{F},V::Function,d,n::Integer) where {F<:Fun}
     error("Reimplement with matrix")
 
 #     wsq=IFun(x->exp(-n/2.*V(x)),d)
@@ -128,7 +128,7 @@ function adaptiveie(w,μ0,α,β,d)
 
     wv=w(pts)
 
-    cfs=chebyshevtransform(pv[:,end].^2.*wv)
+    cfs=chebyshevtransform(pv[:,end] .^2 .* wv)
 
     if maximum(abs(cfs[end-8:end])) < 200*eps()
         ## chop to minimize oversample
@@ -265,8 +265,8 @@ function samplespectra(q::Array{Float64,2},d,plan,pts)
 end
 
 
-function iekernel{F<:Fun}(p::Array{F})
-    ret = 0.*p[1]
+function iekernel(p::Array{F}) where {F<:Fun}
+    ret = 0 .* p[1]
     for i = 1:length(p)
         ret += fasttimes(p[i],p[i])
     end
@@ -274,7 +274,7 @@ function iekernel{F<:Fun}(p::Array{F})
     ret
 end
 
-function samplespectra{F<:Fun}(p::Array{F})
+function samplespectra(p::Array{F}) where {F<:Fun}
     n = length(p)
     r=sample(iekernel(p)/n)
     if n==1

--- a/src/RandomMatrices.jl
+++ b/src/RandomMatrices.jl
@@ -3,6 +3,8 @@ module RandomMatrices
 using Combinatorics
 using GSL
 using SpecialFunctions, FastGaussQuadrature
+using LinearAlgebra
+using Requires
 
 import Base: isinf, rand, convert
 import Distributions: ContinuousUnivariateDistribution,
@@ -50,8 +52,10 @@ include("StatisticalTests.jl")
 include("StochasticProcess.jl")
 
 #Invariant ensembles
-if Pkg.installed("ApproxFun")!== nothing
-    include("InvariantEnsembles.jl")
+function __init__()
+    @require ApproxFun="28f2ccd6-bb30-5033-b560-165f7b14dc2f" begin
+        include("InvariantEnsembles.jl")
+    end
 end
 
 end

--- a/src/StatisticalTests.jl
+++ b/src/StatisticalTests.jl
@@ -4,7 +4,7 @@ import Distributions
 #Mauchly, 1940; Kendall and Stuart, 1968
 #n is the number of data points (samples)
 #This returns both the value of the test statistic and the expected distribution to test against
-function MauchlySphericityTestStatistic{T<:Real}(PopulationCovariance::AbstractMatrix{T}, SampleCovariance::AbstractMatrix{T}, n::Integer)
+function MauchlySphericityTestStatistic(PopulationCovariance::AbstractMatrix{T}, SampleCovariance::AbstractMatrix{T}, n::Integer) where {T<:Real}
     p = size(SampleCovariance)[1]
     C = inv(PopulationCovariance) * SampleCovariance
     l = (det(C)/(trace(C)/p)^p)
@@ -16,7 +16,7 @@ end
 #Johnstone's variant of the sphericity test
 #n, p>= 10 recommended
 #Johnstone (2001)
-function JohnstoneSphericityTestStatistic{T<:Real}(PopulationCovariance::AbstractMatrix{T}, SampleCovariance::AbstractMatrix{T}, n::Integer)
+function JohnstoneSphericityTestStatistic(PopulationCovariance::AbstractMatrix{T}, SampleCovariance::AbstractMatrix{T}, n::Integer) where {T<:Real}
     C = inv(PopulationCovariance) * SampleCovariance
     v = max(eigvals(C))
     mu=(sqrt(n-1)+sqrt(p))^2

--- a/src/densities/Semicircle.jl
+++ b/src/densities/Semicircle.jl
@@ -45,7 +45,7 @@ function pdf(d::Semicircle{T}, x::T) where {T<:Real}
 end
 
 # predicate is x in the support of the distribution?
-insupport{T<:Real}(d::Semicircle{T}, x::T) = abs(x-d.mean) < d.radius
+insupport(d::Semicircle{T}, x::T) where {T<:Real} = abs(x-d.mean) < d.radius
 
 function cdf(X::Semicircle{T}, x::V) where {T<:Real,V<:Real}
 	TV = promote_type(T,V)
@@ -80,13 +80,13 @@ mean(X::Semicircle)=X.mean
 median(X::Semicircle)=X.mean
 
 # mode(s) of distribution as vector
-modes{T}(X::Semicircle{T})=T[X.mean]
+modes(X::Semicircle{T}) where {T} = T[X.mean]
 
 # kurtosis of the distribution
-kurtosis{T}(X::Semicircle{T})=T(2)
+kurtosis(X::Semicircle{T}) where {T} = T(2)
 
 # skewness of the distribution
-skewness{T}(X::Semicircle{T})=T(0)
+skewness(X::Semicircle{T}) where {T} = T(0)
 
 # standard deviation of distribution
 std(X::Semicircle)=X.radius/2

--- a/src/densities/TracyWidom.jl
+++ b/src/densities/TracyWidom.jl
@@ -40,27 +40,27 @@ doi.org/10.1090/S0025-5718-09-02280-7
 * `beta::Integer = 2`: The Dyson index defining the distribution. Takes values 1, 2, or 4
 * `num_points::Integer = 25`: The number of points in the quadrature
 """
-function cdf{T<:Real}(d::TracyWidom, s::T; beta::Integer=2, num_points::Integer=25)
+function cdf(d::TracyWidom, s::T; beta::Integer=2, num_points::Integer=25) where {T<:Real}
     beta ∈ (1,2,4) || throw(ArgumentError("Beta must be 1, 2, or 4"))
     quad = gausslegendre(num_points)
     _TWcdf(s, beta, quad)
 end
 
-function cdf{T<: Real}(d::Type{TracyWidom}, s::T; beta::Integer=2, num_points::Integer=25)
+function cdf(d::Type{TracyWidom}, s::T; beta::Integer=2, num_points::Integer=25) where {T<: Real}
     cdf(d(), s, beta=beta, num_points=num_points)
 end
 
-function cdf{T<:Real}(d::TracyWidom, s_vals::AbstractArray{T}; beta::Integer=2, num_points::Integer=25)
+function cdf(d::TracyWidom, s_vals::AbstractArray{T}; beta::Integer=2, num_points::Integer=25) where {T<:Real}
     beta ∈ (1,2,4) || throw(ArgumentError("Beta must be 1, 2, or 4"))
     quad = gausslegendre(num_points)
     [_TWcdf(s, beta, quad) for s in s_vals]
 end
 
-function cdf{T<:Real}(d::Type{TracyWidom}, s_vals::AbstractArray{T}; beta::Integer=2, num_points::Integer=25)
+function cdf(d::Type{TracyWidom}, s_vals::AbstractArray{T}; beta::Integer=2, num_points::Integer=25) where {T<:Real}
     cdf(d(), s_vals, beta=beta, num_points=num_points)
 end
 
-function _TWcdf{T<:Real}(s::T, beta::Integer, quad::Tuple{Array{Float64,1},Array{Float64,1}})
+function _TWcdf(s::T, beta::Integer, quad::Tuple{Array{Float64,1},Array{Float64,1}}) where {T<:Real}
     if beta == 2
         kernel = ((ξ,η) -> _K2tilde(ξ,η,s))
         return _fredholm_det(kernel, quad)
@@ -76,13 +76,13 @@ function _TWcdf{T<:Real}(s::T, beta::Integer, quad::Tuple{Array{Float64,1},Array
     end
 end
 
-function _fredholm_det{T<:Real}(kernel::Function, quad::Tuple{Array{T,1},Array{T,1}})
+function _fredholm_det(kernel::Function, quad::Tuple{Array{T,1},Array{T,1}}) where {T<:Real}
     nodes, weights = quad
     N = length(nodes)
     sqrt_weights = sqrt.(weights)
     weights_matrix = kron(transpose(sqrt_weights),sqrt_weights)
     K_matrix = [kernel(ξ,η) for ξ in nodes, η in nodes]
-    det(eye(N) - weights_matrix .* K_matrix)
+    det(I - weights_matrix .* K_matrix)
 end
 
 _ϕ(ξ, s) =  s + 10*tan(π*(ξ+1)/4)

--- a/src/dpp.jl
+++ b/src/dpp.jl
@@ -14,7 +14,7 @@ Output:
 
 References:
 
-    Algorithm 18 of \cite{HKPV05}, as described in Algorithm 1 of \cite{KT12}.
+    Algorithm 18 of \\cite{HKPV05}, as described in Algorithm 1 of \\cite{KT12}.
 
     @article{HKPV05,
         author = {Hough, J Ben and Krishnapur, Manjunath and Peres, Yuval and Vir\'{a}g, B\'{a}lint},
@@ -43,7 +43,7 @@ References:
 
     TODO Check loss of orthogonality - a tip from Zelda Mariet
 """
-function rand{S<:Real,T}(L::Base.LinAlg.Eigen{S,T})
+function rand(L::LinearAlgebra.Eigen{S,T}) where {S<:Real,T}
     N = length(L.values)
     J = Int[]
     for n=1:N
@@ -85,5 +85,5 @@ function rand{S<:Real,T}(L::Base.LinAlg.Eigen{S,T})
         V = full(qrfact!(V)[:Q])[:, 1:nV-1]
         nV = size(V, 2)
     end
-    Y
+    return Y
 end

--- a/test/FormalPowerSeries.jl
+++ b/test/FormalPowerSeries.jl
@@ -1,7 +1,9 @@
 using RandomMatrices
-using Base.Test
+using LinearAlgebra: norm
+using Test
 
-srand(4)
+@testset "FormalPowerSeries" begin
+seed!(4)
 
 # Excursions in formal power series (fps)
 MaxSeriesSize=8
@@ -51,11 +53,7 @@ end
 #of the original series
 #Force reciprocal to exist
 X.c[0] = 1
-discrepancy = if Base.VERSION < v"0.5-"
-    (norm(inv(float(MatrixForm(X,c)))[1, :]'[:, 1] - tovector(reciprocal(X, c), 0:c-1)))
-else
-    (norm(inv(float(MatrixForm(X,c)))[1, :][:, 1] - tovector(reciprocal(X, c), 0:c-1)))
-end
+discrepancy = (norm(inv(float(MatrixForm(X,c)))[1, :][:, 1] - tovector(reciprocal(X, c), 0:c-1)))
 tol = c*√eps()
 if discrepancy > tol
     error(string("Error ", discrepancy, " exceeds tolerance ", tol))
@@ -78,3 +76,4 @@ end
 #Test chain rule [H, Sec.1.6, p.40]
 @test derivative(compose(X,Y)) == compose(derivative(X),Y)*derivative(Y)
 
+end # testset

--- a/test/GaussianEnsembles.jl
+++ b/test/GaussianEnsembles.jl
@@ -1,5 +1,7 @@
-using Base.Test
 using RandomMatrices
+using Test
+
+@testset "GaussianEnsembles" begin
 
 @test Wigner{3} == GaussianHermite{3}
 
@@ -25,3 +27,5 @@ for (β, T, N) in [(1, Real, n), (2, Complex, n), (4, Complex, 2n)]
     ed = eigvaljpdf(d, vals)
     @test isa(ed, Real)
 end
+
+end # testset

--- a/test/Haar.jl
+++ b/test/Haar.jl
@@ -1,23 +1,25 @@
 using RandomMatrices
-using Base.Test
+using LinearAlgebra: I, tr
+using Test
 
-if isdefined(:_HAVE_GSL)
+@testset "Haar" begin
+
 N=5
 A=randn(N,N)
 B=randn(N,N)
-Q=UniformHaar(2, N)
+Q=rand(Haar(1), N)
 
 #Test case where there are no symbolic Haar matrices
-@test eval(expectation(N, :Q, :(A*B))) ≈ A*B
+@test_broken eval(expectation(:(A*B))) ≈ A*B
 #Test case where there is one pair of symbolic Haar matrices
-@test eval(expectedtrace(N, :Q, :(A*Q*B*Q'))) ≈ trace(A)*trace(B)/N
+@test_broken tr(eval(expectation(:(A*Q*B*Q')))) ≈ tr(A)*tr(B)/N
 
 println("Case 3")
-println("E(A*Q*B*Q'*A*Q*B*Q') = ", eval(expectation(N, :Q, :(A*Q*B*Q'*A*Q*B*Q'))))
+@test_broken println("E(A*Q*B*Q'*A*Q*B*Q') = ", eval(expectation(N, :Q, :(A*Q*B*Q'*A*Q*B*Q'))))
 
-for elty in (Float64, Complex128)
+for elty in (Float64, ComplexF64)
 	A = Stewart(elty, N)
-	@test A'A ≈ eye(N)
+        @test A'A ≈ Matrix{elty}(I, N, N)
 end
 
-end #_HAVE_GSL
+end # testset

--- a/test/StochasticProcess.jl
+++ b/test/StochasticProcess.jl
@@ -1,27 +1,32 @@
 using RandomMatrices
-using Base.Test
+using Test
 
-srand(1)
+@testset "StochasticProcess" begin
+
+seed!(1)
 dx = 0.001
 
 let
 p = WhiteNoiseProcess(dx)
-@test start(p) == nothing
-S = next(p)
-@test done(p, S) == false
+x, S = iterate(p)
+@test typeof(x) == typeof(dx)
+@test isa(S, Tuple{})
+@test iterate(p, S) != nothing
 end
 
 let
 p = BrownianProcess(dx)
-@test start(p) == 0
-S = next(p, 0.0)
-@test done(p, S) == false
+x, S = iterate(p)
+@test x == S
+@test typeof(x) == typeof(dx)
+@test iterate(p, S) != nothing
 end
 
 let
 p = AiryProcess(dx, 2.0)
-S = start(p)
-@test S == fill(-2/dx^2, 1, 1)
-S = next(p, S)
-@test done(p, S) == false
+x, S = iterate(p)
+@test S[1,1] == -2/dx^2
+@test next!(p, S) != nothing
 end
+
+end # testset

--- a/test/densities/Semicircle.jl
+++ b/test/densities/Semicircle.jl
@@ -1,5 +1,7 @@
 using RandomMatrices
-using Base.Test
+using Test
+
+@testset "Semicircle" begin
 
 let
     d = Semicircle()
@@ -27,4 +29,6 @@ let
     x = rand(d)
     @test insupport(d, x)
 end
+
+end # testset
 

--- a/test/densities/TracyWidom.jl
+++ b/test/densities/TracyWidom.jl
@@ -1,5 +1,7 @@
 using RandomMatrices
-using Compat.Test
+using Test
+
+@testset "TracyWidom" begin
 
 # CDF lies in correct range
 @test all(i->(0<i<1), cdf(TracyWidom, randn(5)))
@@ -15,3 +17,5 @@ using Compat.Test
 
 @test isfinite(rand(TracyWidom, 10))
 @test isfinite(rand(TracyWidom, 100))
+
+end # testset

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,17 @@
 using RandomMatrices
-using Base.Test
+using Random: seed!
+using Test
 
-srand(1)
+@testset "RandomMatrices" begin
+seed!(1)
 include("GaussianEnsembles.jl")
 include("FormalPowerSeries.jl")
 include("Haar.jl")
 include("StochasticProcess.jl")
 
-include("densities/Semicircle.jl")
-include("densities/TracyWidom.jl")
+@testset "densities" begin
+    include("densities/Semicircle.jl")
+    include("densities/TracyWidom.jl")
+end
+end
 


### PR DESCRIPTION
This PR makes `RandomMatrices.jl` pass the tests on v1.0 (although not all of the code is covered)

There are some issues:
- Previously it tested if `ApproxFun.jl` was installed and only then included the file `src/InvariantEnsembles.jl`. This is not possible anymore, so I replaced that functionality with one that loads this file whenever the user calls `using ApproxFun`. This is done using the package `Requires.jl`
- The tests in `test/Haar.jl` call some code that seems to be broken. Previously these tests never got triggered, because they where inside some if-block that was not executed. I now changed these tests to `@test_broken` but that does not change the fact that the function `expectation` in `src/Haar.jl` seems to be broken.
-  I had to change some tests in test/StochasticProcess.jl` because the iteration protocol in Julia changed.